### PR TITLE
Updated unexpected to version 9.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon": "1.17.1",
     "stylus": "0.52.4",
     "swig": "1.4.2",
-    "unexpected": "9.16.0",
+    "unexpected": "9.16.1",
     "unexpected-sinon": "7.3.0"
   }
 }


### PR DESCRIPTION
:rocket:

unexpected just published version 9.16.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 9 commits (ahead by 9, behind by 0).

- [b48b73f](https://github.com/unexpectedjs/unexpected/commit/b48b73f7c751f1957ea787963c92156b18a67610): 9.16.1
- [5a70595](https://github.com/unexpectedjs/unexpected/commit/5a705952ceca6a529e6cf2786624fe52c9fd9280): Build unexpected.js
- [f79fb19](https://github.com/unexpectedjs/unexpected/commit/f79fb19884f4beb46e539dd86793a04de08ce042): Makefile: node_modules/.bin/deploy-site{ => .sh}
- [c2454fd](https://github.com/unexpectedjs/unexpected/commit/c2454fd9ba0625cfbeb54e4fcedec52c41c92bcf): Fix expect(...).and(...).and(...).
- [e1f4b5f](https://github.com/unexpectedjs/unexpected/commit/e1f4b5fc7cce208fe08b6442d8849c011c8c7282): Document 'when called with'. See #217.
- [52bbf0e](https://github.com/unexpectedjs/unexpected/commit/52bbf0e4ff72b359977f58d9049b525db830e832): makePromise: Don't wrap reject in a superfluous function.
- [def0314](https://github.com/unexpectedjs/unexpected/commit/def0314c11dc07e0fc8debda42795306ddf6a31e): upgraded unexpected-documentation-site-generator
- [536c3fb](https://github.com/unexpectedjs/unexpected/commit/536c3fbb06d74a968e71025380ea7e0ddf9d4d9b): Made the execution context private to wrapped expect
- [74cb960](https://github.com/unexpectedjs/unexpected/commit/74cb9605a868b6ef1b2a2b0242bc74f286ff776e): Fixed typos in the "to be a" documentation.

See the [full diff](https://github.com/unexpectedjs/unexpected/compare/5f60dd9f8ea19a1f8ea29987ea252079781cc06c...b48b73f7c751f1957ea787963c92156b18a67610).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>